### PR TITLE
Remove ANSI formatting before measuring string width

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/AlecAivazis/survey/v2
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/creack/pty v1.1.17
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/AlecAivazis/survey/v2
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
+	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/creack/pty v1.1.17
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
-github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -23,7 +21,6 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
+github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -397,7 +397,7 @@ func isAnsiMarker(r rune) bool {
 
 // isAnsiTerminator returns if a rune denotes the end of an ANSI sequence
 func isAnsiTerminator(r rune) bool {
-	return (r >= 0x40 && r <= 0x5a) || (r >= 0x61 && r <= 0x7a)
+	return (r >= 0x40 && r <= 0x5a) || (r == 0x5e) || (r >= 0x60 && r <= 0x7e)
 }
 
 // StringWidth returns the visible width of a string when printed to the terminal

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"unicode"
 
+	"github.com/acarl005/stripansi"
 	"golang.org/x/text/width"
 )
 
@@ -377,17 +378,24 @@ func (rr *RuneReader) ReadLineWithDefault(mask rune, d []rune, onRunes ...OnRune
 	}
 }
 
+// runeWidth returns the number of columns spanned by a rune when printed to the terminal
 func runeWidth(r rune) int {
 	switch width.LookupRune(r).Kind() {
 	case width.EastAsianWide, width.EastAsianFullwidth:
 		return 2
 	}
+
+	if !unicode.IsPrint(r) {
+		return 0
+	}
 	return 1
 }
 
+// StringWidth returns the visible width of a string when printed to the terminal
 func StringWidth(str string) int {
 	w := 0
-	rs := []rune(str)
+	cleanedStr := stripansi.Strip(str)
+	rs := []rune(cleanedStr)
 	for _, r := range rs {
 		w += runeWidth(r)
 	}

--- a/terminal/runereader_test.go
+++ b/terminal/runereader_test.go
@@ -1,0 +1,59 @@
+package terminal
+
+import (
+	"testing"
+)
+
+func TestRuneWidthInvisible(t *testing.T) {
+	var example rune = '⁣'
+	expected := 0
+	actual := runeWidth(example)
+	if actual != expected {
+		t.Errorf("Expected '%c' to have width %d, found %d", example, expected, actual)
+	}
+}
+
+func TestRuneWidthNormal(t *testing.T) {
+	var example rune = 'a'
+	expected := 1
+	actual := runeWidth(example)
+	if actual != expected {
+		t.Errorf("Expected '%c' to have width %d, found %d", example, expected, actual)
+	}
+}
+
+func TestRuneWidthWide(t *testing.T) {
+	var example rune = '错'
+	expected := 2
+	actual := runeWidth(example)
+	if actual != expected {
+		t.Errorf("Expected '%c' to have width %d, found %d", example, expected, actual)
+	}
+}
+
+func TestStringWidthEmpty(t *testing.T) {
+	example := ""
+	expected := 0
+	actual := StringWidth(example)
+	if actual != expected {
+		t.Errorf("Expected '%s' to have width %d, found %d", example, expected, actual)
+	}
+}
+
+func TestStringWidthNormal(t *testing.T) {
+	example := "Green"
+	expected := 5
+	actual := StringWidth(example)
+	if actual != expected {
+		t.Errorf("Expected '%s' to have width %d, found %d", example, expected, actual)
+	}
+}
+
+func TestStringWidthFormat(t *testing.T) {
+	example := "\033[31mRed\033[0m"
+	expected := 3
+	actual := StringWidth(example)
+	if actual != expected {
+		t.Errorf("Expected '%s' to have width %d, found %d", example, expected, actual)
+	}
+}

--- a/terminal/runereader_test.go
+++ b/terminal/runereader_test.go
@@ -56,4 +56,11 @@ func TestStringWidthFormat(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Expected '%s' to have width %d, found %d", example, expected, actual)
 	}
+
+	example = "\033[1;34mbold\033[21mblue\033[0m"
+	expected = 8
+	actual = StringWidth(example)
+	if actual != expected {
+		t.Errorf("Expected '%s' to have width %d, found %d", example, expected, actual)
+	}
 }


### PR DESCRIPTION
### Summary

Hello! This PR hopes to address an issue in the select prompt where formatted lines may delete the past output on terminals of certain sizes.

### The problem

When [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) are used in the options of a prompt, these lines are measured wider than what is visibly printed to the terminal. This is caused by the `StringWidth` counting these escaped characters as a part of the actual string, and results in previous output being deleted (if the measured line count is greater than the actual line count of an option).

The following can demonstrate this on terminals that are only slightly wider than the option's visible length:

```go
prompt := &survey.Select{
  Message: "Select an option:",
  Options: []string{
    "\033[35m..........................................................",
    "\033[36m..........................................................",
  },
}

survey.AskOne(prompt, "")
```

See this in action:

https://user-images.githubusercontent.com/18134219/198906355-71ca8926-61e6-4af0-8c44-9adf03a8604a.mov

### Proposed solution

The [`github.com/acarl005/stripansi` library](https://github.com/acarl005/stripansi) offers a nice regex pattern to remove ANSI codes, and when used in the `StringWidth` method can remove these codes before the string's width is measured. 

Additionally, a check for non-printable runes was added to the `runeWidth` method so that only printable characters are measured. [`unicode.IsPrint`](https://pkg.go.dev/unicode#IsPrint) was chosen over [`unicode.IsGraphic`](https://pkg.go.dev/unicode#IsGraphic) to conform with the definitions of Go, but I could see a reason for preferring `IsGraphic`!

With the changes of this PR applied, the following result is achieved:

https://user-images.githubusercontent.com/18134219/198907296-7fcfa73a-4f78-4a20-990a-f203f03202b7.mov