### PR TITLE
Add option to remove filters from select-type prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ survey.AskOne(prompt, &content)
 By default, the user can filter for options in Select and MultiSelects by typing while the prompt
 is active. This will filter out all options that don't contain the typed string anywhere in their name, ignoring case.
 
+### Defining a custom filter
+
 A custom filter function can also be provided to change this behavior:
 
 ```golang
@@ -287,7 +289,7 @@ func myFilter(filterValue string, optValue string, optIndex int) bool {
 survey.AskOne(prompt, &color, survey.WithFilter(myFilter))
 ```
 
-## Keeping the filter active
+### Keeping the filter active
 
 By default the filter will disappear if the user selects one of the filtered elements. Once the user selects one element the filter setting is gone.
 
@@ -303,6 +305,20 @@ However the user can prevent this from happening and keep the filter active for 
 
 // or define a default for all of the questions
 survey.AskOne(prompt, &color, survey.WithKeepFilter(true))
+```
+
+### Removing filters
+
+Filtering can be removed from a prompt with the `HideFilter` option, restricting selection movements to only the arrow keys, as follows:
+
+```golang
+prompt := &survey.Select{
+    Message: "Choose a color:",
+    Options: []string{"red", "blue", "green"},
+    HideFilter: true,
+}
+
+survey.AskOne(prompt, &color)
 ```
 
 ## Validation

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -770,6 +770,33 @@ func TestMultiSelectPromptHideFilter(t *testing.T) {
 				{Value: "yellow", Index: 3},
 			},
 		},
+		{
+			"verify that help text is shown when requested, even if the filter is hidden",
+			&MultiSelect{
+				Message:    "What color do you prefer:",
+				Options:    []string{"green", "red", "blue", "yellow"},
+				Help:       "We all have a favorite :)",
+				HideFilter: true,
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move, space to select, <right> to all, <left> to none, ? for more help]")
+				// Display help message
+				c.Send("?")
+				c.ExpectString("We all have a favorite :)")
+				// Select "green"
+				c.Send(" ")
+				// Select "blue"
+				c.Send(string(terminal.KeyArrowDown))
+				c.Send(string(terminal.KeyArrowDown))
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]core.OptionAnswer{
+				{Value: "green", Index: 0},
+				{Value: "blue", Index: 2},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/multiselect_test.go
+++ b/multiselect_test.go
@@ -697,6 +697,88 @@ func TestMultiSelectPromptKeepFilter(t *testing.T) {
 	}
 }
 
+func TestMultiSelectPromptHideFilter(t *testing.T) {
+	tests := []PromptTest{
+		{
+			"attempt to filter and select end options when the filter is hidden",
+			&MultiSelect{
+				Message:    "What color do you prefer:",
+				Options:    []string{"green", "red", "blue", "yellow"},
+				HideFilter: true,
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move, space to select, <right> to all, <left> to none]")
+				// Attempt to filter "blue" and "yellow"
+				c.Send("l")
+				// Select "green"
+				c.Send(" ")
+				// Select "red"
+				c.Send(string(terminal.KeyArrowDown))
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]core.OptionAnswer{
+				{Value: "green", Index: 0},
+				{Value: "red", Index: 1},
+			},
+		},
+		{
+			"filter and select end options when the filter is clearly not hidden",
+			&MultiSelect{
+				Message:    "What color do you prefer:",
+				Options:    []string{"green", "red", "blue", "yellow"},
+				HideFilter: false,
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]")
+				// Filter "blue" and "yellow"
+				c.Send("l")
+				// Select "blue"
+				c.Send(" ")
+				// Select "yellow"
+				c.Send(string(terminal.KeyArrowDown))
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]core.OptionAnswer{
+				{Value: "blue", Index: 2},
+				{Value: "yellow", Index: 3},
+			},
+		},
+		{
+			"filter and select end options using the default filter behavior",
+			&MultiSelect{
+				Message: "What color do you prefer:",
+				Options: []string{"green", "red", "blue", "yellow"},
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move, space to select, <right> to all, <left> to none, type to filter]")
+				// Filter "blue" and "yellow"
+				c.Send("l")
+				// Select "blue"
+				c.Send(" ")
+				// Select "yellow"
+				c.Send(string(terminal.KeyArrowDown))
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			[]core.OptionAnswer{
+				{Value: "blue", Index: 2},
+				{Value: "yellow", Index: 3},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			RunPromptTestKeepFilter(t, test)
+		})
+	}
+}
+
 func TestMultiSelectPromptRemoveSelectAll(t *testing.T) {
 	tests := []PromptTest{
 		{

--- a/select_test.go
+++ b/select_test.go
@@ -374,3 +374,70 @@ func TestSelectPrompt(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectPromptHideFilter(t *testing.T) {
+	tests := []PromptTest{
+		{
+			"attempt to filter and select the end option when the filter is hidden",
+			&Select{
+				Message:    "What color do you prefer:",
+				Options:    []string{"green", "red", "blue"},
+				HideFilter: true,
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move]")
+				// Attempt to filter "blue"
+				c.Send("b")
+				// Select "green"
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			core.OptionAnswer{
+				Value: "green", Index: 0,
+			},
+		},
+		{
+			"filter and select the end option when the filter is clearly not hidden",
+			&Select{
+				Message:    "What color do you prefer:",
+				Options:    []string{"green", "red", "blue"},
+				HideFilter: false,
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move, type to filter]")
+				// Filter "blue"
+				c.Send("b")
+				// Select "blue"
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			core.OptionAnswer{
+				Value: "blue", Index: 2,
+			},
+		},
+		{
+			"filter and select the end option using the default filter behavior",
+			&Select{
+				Message: "What color do you prefer:",
+				Options: []string{"green", "red", "blue"},
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move, type to filter]")
+				// Filter "blue"
+				c.Send("l")
+				// Select "blue"
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			core.OptionAnswer{
+				Value: "blue", Index: 2,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			RunPromptTestKeepFilter(t, test)
+		})
+	}
+}

--- a/select_test.go
+++ b/select_test.go
@@ -433,6 +433,28 @@ func TestSelectPromptHideFilter(t *testing.T) {
 				Value: "blue", Index: 2,
 			},
 		},
+		{
+			"verify that help text is shown when requested, even if the filter is hidden",
+			&Select{
+				Message:    "What color do you prefer:",
+				Options:    []string{"green", "red", "blue"},
+				Help:       "We all have a favorite :)",
+				HideFilter: true,
+			},
+			func(c expectConsole) {
+				c.ExpectString("What color do you prefer:  [Use arrows to move, ? for more help]")
+				// Display help message
+				c.Send("?")
+				c.ExpectString("We all have a favorite :)")
+				// Select "green"
+				c.Send(" ")
+				c.SendLine("")
+				c.ExpectEOF()
+			},
+			core.OptionAnswer{
+				Value: "green", Index: 0,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Summary

This PR provides an option to remove the filter from the `Select` and `MultiSelect` prompts. This is given as an option to restrict selection movement to the arrow keys to prevent options from being hidden by accidental keystrokes. 👻

### Preview

#### `Select`

```go
color := ""
prompt := &survey.Select{
    Message:    "Select a color:",
    Options:    []string{"red", "blue", "green"},
    HideFilter: true,
}

survey.AskOne(prompt, &color)
```

<img width="580" alt="The select prompt without an option to filter" src="https://user-images.githubusercontent.com/18134219/198921986-4adce21f-5bc2-45bb-b807-a89674fede66.png">

#### `MultiSelect`

```go
days := []string{}
prompt := &survey.MultiSelect{
    Message:    "What days do you prefer:",
    Options:    []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"},
    HideFilter: true,
}
survey.AskOne(prompt, &days)
```

<img width="817" alt="The multiselect prompt without an option to filter" src="https://user-images.githubusercontent.com/18134219/198922024-88d2dfb9-1fd8-4922-8816-993981e9bb54.png">


### Notes

- A `HideFilter` option was not added to the global `PromptConfig`. This was (not) done since `HideFilter: true` in the `PromptConfig` would be overridden by the default value of `HideFilter: false` in prompts where this value is not defined.
- `HelpInput` isn't impacted by the removal of filtering, meaning `.Help` text will still be shown after pressing the help key.