### PR TITLE
Add build tags to make the project compatible with gopls

### DIFF
--- a/examples/countrylist.go
+++ b/examples/countrylist.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/cursor.go
+++ b/examples/cursor.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/inputfilesuggestion.go
+++ b/examples/inputfilesuggestion.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/longlist.go
+++ b/examples/longlist.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/longmulti.go
+++ b/examples/longmulti.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/longmultikeepfilter.go
+++ b/examples/longmultikeepfilter.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/map.go
+++ b/examples/map.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/password.go
+++ b/examples/password.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/select_description.go
+++ b/examples/select_description.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/examples/validation.go
+++ b/examples/validation.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/ask.go
+++ b/tests/ask.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/confirm.go
+++ b/tests/confirm.go
@@ -1,8 +1,10 @@
+//go:build ignore
+
 package main
 
 import (
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/tests/util"
+	TestUtil "github.com/AlecAivazis/survey/v2/tests/util"
 )
 
 var answer = false

--- a/tests/doubleSelect.go
+++ b/tests/doubleSelect.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/editor.go
+++ b/tests/editor.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (
@@ -5,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/tests/util"
+	TestUtil "github.com/AlecAivazis/survey/v2/tests/util"
 )
 
 var answer = ""

--- a/tests/help.go
+++ b/tests/help.go
@@ -1,8 +1,10 @@
+//go:build ignore
+
 package main
 
 import (
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/tests/util"
+	TestUtil "github.com/AlecAivazis/survey/v2/tests/util"
 )
 
 var (

--- a/tests/input.go
+++ b/tests/input.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/longSelect.go
+++ b/tests/longSelect.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import "github.com/AlecAivazis/survey/v2"

--- a/tests/multiselect.go
+++ b/tests/multiselect.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (

--- a/tests/password.go
+++ b/tests/password.go
@@ -1,8 +1,10 @@
+//go:build ignore
+
 package main
 
 import (
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/tests/util"
+	TestUtil "github.com/AlecAivazis/survey/v2/tests/util"
 )
 
 var value = ""

--- a/tests/select.go
+++ b/tests/select.go
@@ -1,8 +1,10 @@
+//go:build ignore
+
 package main
 
 import (
 	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/tests/util"
+	TestUtil "github.com/AlecAivazis/survey/v2/tests/util"
 )
 
 var answer = ""

--- a/tests/selectThenInput.go
+++ b/tests/selectThenInput.go
@@ -1,3 +1,5 @@
+//go:build ignore
+
 package main
 
 import (


### PR DESCRIPTION
The gopls deamon for text editor integrations used to complain about the `main()` function being redeclared across multiple `package main` files that share the same directory. This is because these individual scripts were meant to be run with `go run path/to/file.go` instead of being built as a binary.

The latest gopls release supports recognizing files that are meant as individual runnable scripts, but they must be tagged with a build tag that makes them otherwise ignored.