### PR TITLE
Output plain template when NO_COLOR environment variable is set

### DIFF
--- a/core/template.go
+++ b/core/template.go
@@ -24,6 +24,17 @@ var TemplateFuncsNoColor = map[string]interface{}{
 	},
 }
 
+// envColorDisabled returns if output colors are forbid by environment variables
+func envColorDisabled() bool {
+	return os.Getenv("NO_COLOR") != "" || os.Getenv("CLICOLOR") == "0"
+}
+
+// envColorForced returns if output colors are forced from environment variables
+func envColorForced() bool {
+	val, ok := os.LookupEnv("CLICOLOR_FORCE")
+	return ok && val != "0"
+}
+
 // RunTemplate returns two formatted strings given a template and
 // the data it requires. The first string returned is generated for
 // user-facing output and may or may not contain ANSI escape codes
@@ -75,7 +86,8 @@ func GetTemplatePair(tmpl string) ([2]*template.Template, error) {
 
 	templatePair[1] = templateNoColor
 
-	if DisableColor || os.Getenv("NO_COLOR") != "" {
+	envColorHide := envColorDisabled() && !envColorForced()
+	if DisableColor || envColorHide {
 		templatePair[0] = templatePair[1]
 	} else {
 		templateWithColor, err := template.New("prompt").Funcs(TemplateFuncsWithColor).Parse(tmpl)

--- a/core/template.go
+++ b/core/template.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"os"
 	"sync"
 	"text/template"
 
@@ -74,7 +75,7 @@ func GetTemplatePair(tmpl string) ([2]*template.Template, error) {
 
 	templatePair[1] = templateNoColor
 
-	if DisableColor {
+	if DisableColor || os.Getenv("NO_COLOR") != "" {
 		templatePair[0] = templatePair[1]
 	} else {
 		templateWithColor, err := template.New("prompt").Funcs(TemplateFuncsWithColor).Parse(tmpl)


### PR DESCRIPTION
### Summary

This PR checks for a non-empty `NO_COLOR` environment variable and displays templates without color if one is present, as specified by the references in #447.

Fixes #447

### Preview

https://user-images.githubusercontent.com/18134219/205460922-8b6a854b-e4e6-4daf-93b8-3e8ed63ca6be.mov

### Reviewers

The following steps can be used to inspect these changes:

1. Checkout this branch
2. In a project using `survey`, append the following to your `go.mod`, pointing to your local `survey` source:

```
replace github.com/AlecAivazis/survey/v2 v2.3.6 => ../../go-survey/survey
```

3. Run your project with color support by ensuring `NO_COLOR` is not set:

```sh
$ unset NO_COLOR
$ ./your-survey-project
```

4. Run your project with colors removed from `survey` outputs:

```sh
$ export NO_COLOR=true
$ ./your-survey-project
```

### Notes

- No modifications are made to user-passed prompt values such as `Message`, `Options`, `Help`, and so forth. Removing color from these values is instead left to the caller of this package.