### PR TITLE
Clear to end of screen before redrawing prompt

### DIFF
--- a/multiline.go
+++ b/multiline.go
@@ -86,12 +86,12 @@ func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 		multiline = append(multiline, string(line))
 	}
 
+	// remove the trailing newline
+	multiline = multiline[:len(multiline)-1]
 	val := strings.Join(multiline, "\n")
-	val = strings.TrimSpace(val)
 
-	// if the line is empty
+	// use the default value if the line is empty
 	if len(val) == 0 {
-		// use the default value
 		return i.Default, err
 	}
 

--- a/multiline.go
+++ b/multiline.go
@@ -2,8 +2,6 @@ package survey
 
 import (
 	"strings"
-
-	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
 type Multiline struct {
@@ -28,12 +26,12 @@ var MultilineQuestionTemplate = `
 {{- color .Config.Icons.Question.Format }}{{ .Config.Icons.Question.Text }} {{color "reset"}}
 {{- color "default+hb"}}{{ .Message }} {{color "reset"}}
 {{- if .ShowAnswer}}
-  {{- "\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}
-  {{- if .Answer }}{{ "\n" }}{{ end }}
+  {{- if .Answer}}{{"\n"}}{{color "cyan"}}{{.Answer}}{{color "reset"}}{{end}}
 {{- else }}
   {{- if .Default}}{{color "white"}}({{.Default}}) {{color "reset"}}{{end}}
   {{- color "cyan"}}[Enter 2 empty lines to finish]{{color "reset"}}
-{{- end}}`
+{{- end}}
+`
 
 func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 	// render the template
@@ -70,13 +68,6 @@ func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 
 		if string(line) == "" {
 			if emptyOnce {
-				numLines := len(multiline) + 2
-				cursor.PreviousLine(numLines)
-				for j := 0; j < numLines; j++ {
-					terminal.EraseLine(i.Stdio().Out, terminal.ERASE_LINE_ALL)
-					cursor.NextLine(1)
-				}
-				cursor.PreviousLine(numLines)
 				break
 			}
 			emptyOnce = true
@@ -85,6 +76,15 @@ func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 		}
 		multiline = append(multiline, string(line))
 	}
+
+	// position the cursor on last line of input
+	cursorPadding := 3
+
+	// ignore the empty line in an empty answer
+	if len(multiline) == 1 && multiline[0] == "" {
+		cursorPadding = 2
+	}
+	cursor.PreviousLine(cursorPadding)
 
 	// remove the trailing newline
 	multiline = multiline[:len(multiline)-1]

--- a/renderer.go
+++ b/renderer.go
@@ -160,8 +160,7 @@ func (r *Renderer) termWidthSafe() int {
 // countLines will return the count of `\n` with the addition of any
 // lines that have wrapped due to narrow terminal width
 func (r *Renderer) countLines(buf bytes.Buffer) int {
-	w := r.termWidthSafe()
-
+	termWidth := r.termWidthSafe()
 	bufBytes := buf.Bytes()
 
 	count := 0
@@ -178,10 +177,11 @@ func (r *Renderer) countLines(buf bytes.Buffer) int {
 		}
 
 		str := string(bufBytes[curr:delim])
-		if lineWidth := terminal.StringWidth(str); lineWidth > w {
+		lineWidth := terminal.StringWidth(str)
+		if lineWidth > termWidth {
 			// account for word wrapping
-			count += lineWidth / w
-			if (lineWidth % w) == 0 {
+			count += lineWidth / termWidth
+			if (lineWidth % termWidth) == 0 {
 				// content whose width is exactly a multiplier of available width should not
 				// count as having wrapped on the last line
 				count -= 1

--- a/renderer.go
+++ b/renderer.go
@@ -42,14 +42,7 @@ func (r *Renderer) NewCursor() *terminal.Cursor {
 }
 
 func (r *Renderer) Error(config *PromptConfig, invalid error) error {
-	// cleanup the currently rendered errors
-	r.resetPrompt(r.countLines(r.renderedErrors))
-	r.renderedErrors.Reset()
-
-	// cleanup the rest of the prompt
-	r.resetPrompt(r.countLines(r.renderedText))
-	r.renderedText.Reset()
-
+	// create a formatted and plain error template with data
 	userOut, layoutOut, err := core.RunTemplate(ErrorTemplate, &ErrorTemplateData{
 		Error: invalid,
 		Icon:  config.Icons.Error,
@@ -58,7 +51,14 @@ func (r *Renderer) Error(config *PromptConfig, invalid error) error {
 		return err
 	}
 
-	// send the message to the user
+	// erase the currently rendered error and prompt
+	r.resetPrompt(r.countLines(r.renderedErrors))
+	r.renderedErrors.Reset()
+
+	r.resetPrompt(r.countLines(r.renderedText))
+	r.renderedText.Reset()
+
+	// print the formatted prompt
 	if _, err := fmt.Fprint(terminal.NewAnsiStdout(r.stdio.Out), userOut); err != nil {
 		return err
 	}
@@ -78,18 +78,17 @@ func (r *Renderer) OffsetCursor(offset int) {
 }
 
 func (r *Renderer) Render(tmpl string, data interface{}) error {
-	// cleanup the currently rendered text
-	lineCount := r.countLines(r.renderedText)
-	r.resetPrompt(lineCount)
-	r.renderedText.Reset()
-
-	// render the template summarizing the current state
+	// create a formatted and plain template with data
 	userOut, layoutOut, err := core.RunTemplate(tmpl, data)
 	if err != nil {
 		return err
 	}
 
-	// print the summary
+	// erase the currently rendered prompt
+	r.resetPrompt(r.countLines(r.renderedText))
+	r.renderedText.Reset()
+
+	// print the formatted prompt
 	if _, err := fmt.Fprint(terminal.NewAnsiStdout(r.stdio.Out), userOut); err != nil {
 		return err
 	}

--- a/renderer.go
+++ b/renderer.go
@@ -129,16 +129,11 @@ func (r *Renderer) AppendRenderedText(text string) {
 	r.renderedText.WriteString(text)
 }
 
+// resetPrompt clears the previous lines of the past prompt
 func (r *Renderer) resetPrompt(lines int) {
-	// clean out current line in case tmpl didnt end in newline
 	cursor := r.NewCursor()
-	cursor.HorizontalAbsolute(0)
-	terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
-	// clean up what we left behind last time
-	for i := 0; i < lines; i++ {
-		cursor.PreviousLine(1)
-		terminal.EraseLine(r.stdio.Out, terminal.ERASE_LINE_ALL)
-	}
+	cursor.PreviousLine(lines)
+	terminal.EraseScreen(r.stdio.Out, terminal.ERASE_SCREEN_END)
 }
 
 func (r *Renderer) termWidth() (int, error) {

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -47,18 +47,24 @@ func (c *Cursor) Back(n int) error {
 
 // NextLine moves cursor to beginning of the line n lines down.
 func (c *Cursor) NextLine(n int) error {
-	if err := c.Down(1); err != nil {
+	if err := c.HorizontalAbsolute(0); err != nil {
 		return err
 	}
-	return c.HorizontalAbsolute(0)
+	if n == 0 {
+		return nil
+	}
+	return c.Down(n)
 }
 
 // PreviousLine moves cursor to beginning of the line n lines up.
 func (c *Cursor) PreviousLine(n int) error {
-	if err := c.Up(1); err != nil {
+	if err := c.HorizontalAbsolute(0); err != nil {
 		return err
 	}
-	return c.HorizontalAbsolute(0)
+	if n == 0 {
+		return nil
+	}
+	return c.Up(n)
 }
 
 // HorizontalAbsolute moves cursor horizontally to x.

--- a/terminal/display.go
+++ b/terminal/display.go
@@ -1,9 +1,25 @@
 package terminal
 
+import (
+	"fmt"
+)
+
 type EraseLineMode int
+type EraseScreenMode int
 
 const (
 	ERASE_LINE_END EraseLineMode = iota
 	ERASE_LINE_START
 	ERASE_LINE_ALL
 )
+
+const (
+	ERASE_SCREEN_END EraseScreenMode = iota
+	ERASE_SCREEN_START
+	ERASE_SCREEN_ALL
+)
+
+func EraseScreen(out FileWriter, mode EraseScreenMode) error {
+	_, err := fmt.Fprintf(out, "\x1b[%dJ", mode)
+	return err
+}


### PR DESCRIPTION
### Summary

This PR adds a `terminal.EraseScreen` function to support the "Erase in Display" ANSI control sequence. This function replaces calls to `terminal.ClearLine` in `resetPrompt` in order to clear previous prompt output entirely and atomically, instead of clearing each line in an iterative manner.

Updating `resetPrompt` to clear to the end of the screen seems to significantly reduce the "flickering" effect noted in #436 since fewer updates to the terminal screen are made between each render.

Additionally, the `MultiLine` prompt was updated as a result of changes to the `resetPrompt` logic. This prompt now preserves leading and trailing spaces in answers and replaces the input template with an answered template after submission. The template was also updated to begin inputs on a newline, which happens to be a request of #336.

### Preview

#### Before

https://user-images.githubusercontent.com/18134219/205465447-cda292c1-bb7b-4ef3-af26-aa450b00791b.mp4

#### After

https://user-images.githubusercontent.com/18134219/205465499-ed0040e4-80ec-49e8-b0df-9223258a1b10.mp4

### Reviewers

The following steps can be used to inspect these changes:

1. Checkout this branch
2. In a project using `survey` and `survey.Select`, `survey.MultiSelect`, or `survey.MultiLine`, append the following to your `go.mod`, pointing to your local `survey` source:
```
replace github.com/AlecAivazis/survey/v2 v2.3.6 => ../../go-survey/survey
```

3. Run your project and rapidly page through select options in an attempt to reproduce the flickering effect.

### Notes

- Flickering is not entirely removed since there is brief moment between clearing the past prompt and outputting the updated one where the erased screen might be shown. This seems to be a fairly rare occurrence though, only happening a handful of times in my testing. The "synchronized update" suggestion from @dnkl would likely prevent this, but I had some difficulties in implementing this.

- This has not been tested with a Windows terminal, however I presume this escape code is properly handled as "[virtual terminal sequences are recommended](https://learn.microsoft.com/en-us/windows/console/classic-vs-vt#recommendations)" when developing for Windows.
  - These changes are also likely to impact the updates in #474, as both PRs are modifying the logic of `resetPrompt`.

- These changes do not seem to impact the current behavior shown in #452.