### PR TITLE
Allow hiding password length

### DIFF
--- a/survey.go
+++ b/survey.go
@@ -256,7 +256,8 @@ func WithShowCursor(ShowCursor bool) AskOpt {
 	}
 }
 
-// WithHideCharacter sets the default character shown instead of the password for password inputs
+// WithHideCharacter sets the default character shown instead of the password for password inputs.
+// A space can be used to hide the password length by not printing anything.
 func WithHideCharacter(char rune) AskOpt {
 	return func(options *AskOptions) error {
 		// set the hide character

--- a/terminal/runereader.go
+++ b/terminal/runereader.go
@@ -26,6 +26,10 @@ func (rr *RuneReader) printChar(char rune, mask rune) error {
 		_, err := fmt.Fprintf(rr.stdio.Out, "%c", char)
 		return err
 	}
+	// if the mask is a space, don't print anything
+	if mask == ' ' {
+		return nil
+	}
 	// otherwise print the mask we were given
 	_, err := fmt.Fprintf(rr.stdio.Out, "%c", mask)
 	return err


### PR DESCRIPTION
Addresses [comments](https://github.com/go-survey/survey/issues/386#issuecomment-1494792529) to #386

This PR allows you to set the `HideCharacter` to a space which will be interpreted by the RuneReader to mean that the user input should not be echoed and that it shouldn't print a "mask" either.