### PR TITLE
Fix bug when deal with input value of `uint`.

### DIFF
--- a/core/write.go
+++ b/core/write.go
@@ -268,7 +268,7 @@ func copy(t reflect.Value, v reflect.Value) (err error) {
 			}
 		case reflect.Uint:
 			var val64 uint64
-			val64, casterr = strconv.ParseUint(vString, 10, 8)
+			val64, casterr = strconv.ParseUint(vString, 10, 0)
 			if casterr == nil {
 				castVal = uint(val64)
 			}


### PR DESCRIPTION
hi, guys,  there is a bug when parsing input unit value larger than 255.

here is a example to reproduce the bug.
```
package main

import (
	"github.com/AlecAivazis/survey/v2"
)

func main() {
	var max uint
	if err := survey.AskOne(&survey.Input{
		Message: "Which is the unit value?",
	}, &max); err != nil {
		panic(err)
	}
	print(max)
}

```

<img width="640" alt="image" src="https://user-images.githubusercontent.com/13963737/230417186-f9836f9e-210f-41e7-bd9c-6ff0a410f85d.png">



And we should set `bitSize` to 0 when calling `parseUint`, which means let the operating system determine the appropriate `bitSize`.