### PR TITLE
Fix multi-line clean-up issue

### DIFF
--- a/multiline.go
+++ b/multiline.go
@@ -2,8 +2,6 @@ package survey
 
 import (
 	"strings"
-
-	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
 type Multiline struct {
@@ -70,13 +68,7 @@ func (i *Multiline) Prompt(config *PromptConfig) (interface{}, error) {
 
 		if string(line) == "" {
 			if emptyOnce {
-				numLines := len(multiline) + 2
-				cursor.PreviousLine(numLines)
-				for j := 0; j < numLines; j++ {
-					terminal.EraseLine(i.Stdio().Out, terminal.ERASE_LINE_ALL)
-					cursor.NextLine(1)
-				}
-				cursor.PreviousLine(numLines)
+				cursor.PreviousLine(3)
 				break
 			}
 			emptyOnce = true

--- a/terminal/cursor.go
+++ b/terminal/cursor.go
@@ -47,7 +47,7 @@ func (c *Cursor) Back(n int) error {
 
 // NextLine moves cursor to beginning of the line n lines down.
 func (c *Cursor) NextLine(n int) error {
-	if err := c.Down(1); err != nil {
+	if err := c.Down(n); err != nil {
 		return err
 	}
 	return c.HorizontalAbsolute(0)
@@ -55,7 +55,7 @@ func (c *Cursor) NextLine(n int) error {
 
 // PreviousLine moves cursor to beginning of the line n lines up.
 func (c *Cursor) PreviousLine(n int) error {
-	if err := c.Up(1); err != nil {
+	if err := c.Up(n); err != nil {
 		return err
 	}
 	return c.HorizontalAbsolute(0)


### PR DESCRIPTION
There seems to be a bug with clean-up of multi-line prompt, as it leaves most of the old text on screen and renders clean-up template underneath (running on MacOS with iTerm2).  This PR seems to fix the issue in my case, hoping that it does not introduce other side-effects elsewhere in other prompts or scenarios.  I would be happy to add a test for that, but I'm really not clear on how to test clean-up rendering.